### PR TITLE
Allowed session to be a callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,36 +61,35 @@ Python 3.8
 
 `pip install kungfuai-sql-chemistry`
 
-#### Automatic Connection to AWS
+#### Database Registration
 Simply create a database dictionary, and call the `register_database` entrypoint.
-```python
-database_map = {
-    "main": AwsDbConfig().detect_db_config("main")
-}
 
-register_database(database_map)
+```python
+def db_init():
+  database_map = {
+      "main": AwsDbConfig().detect_db_config("main")
+  }
+  register_databases(database_map)
 ```
 
-Access your SQLAlchemy engines through the `engines` import.
-After you've called `register_databases`, the configuration has already been detected and setup for usage.
+#### Engine access
+- Use this import to access all engines
 ```
 from kfai_sql_chemistry.db.main import engines
 ```
 
-Notes:
-- Place this code in your `__init__.py` in your `src` directory. 
-  `AppSession` will know use the engines created from the `register_database` call.
-  
+- Use `AppSession().get_bind()` to access the connectable directly (likely an engine)
 
-- If your environment has a AWS Secret Key, then the auto-detection will use it.
-  
 
-- We identify the config based on the input "db_name". For instance, `main` will map to a
-  secret key in `env` named MAIN_DB_SECRET_ID.
-  
+#### Configuration Identification
+AwsDbConfig searches by the following convention
 
-- If no secret ID is found, we search for a db config listing. Please view the example envs to view the requirements.
+1. Search for {prefix}_DB_SECRET_ID
+2. Search for {prefix}_DB_HOST / PORT / NAME / etc...
 
+where `prefix` is a name like "MAIN". 
+
+Check the examples in the repo for more information.
 
 
 <!-- ROADMAP -->

--- a/kfai_sql_chemistry/aws/aws_db_config.py
+++ b/kfai_sql_chemistry/aws/aws_db_config.py
@@ -21,8 +21,11 @@ class AwsDbConfig:
     def _secrets_client(self):
         if not self._boto3_secrets_client:
             return _create_default_client()
-        else:
-            return self._boto3_secrets_client
+
+        if callable(self._boto3_secrets_client):
+            return self._boto3_secrets_client()
+
+        return self._boto3_secrets_client
 
     def detect_db_config(self, db_name: str) -> DatabaseConfig:
         db_name_str = db_name.upper()

--- a/kfai_sql_chemistry/db/database_config.py
+++ b/kfai_sql_chemistry/db/database_config.py
@@ -20,7 +20,7 @@ class DatabaseConfig:
     @staticmethod
     def from_local_env(prefix_str: str):
         prefix_caps = prefix_str.upper()
-        return DatabaseConfig(
+        cfg = DatabaseConfig(
             username=os.getenv(f"{prefix_caps}_DB_USERNAME"),
             password=os.getenv(f"{prefix_caps}_DB_PASSWORD"),
             engine=os.getenv(f"{prefix_caps}_DB_ENGINE"),
@@ -28,6 +28,7 @@ class DatabaseConfig:
             port=int(os.getenv(f"{prefix_caps}_DB_PORT")),
             db_name=os.getenv(f"{prefix_caps}_DB_NAME"),
         )
+        return cfg
 
     def make_url(self):
         return URL(

--- a/kfai_sql_chemistry/test/test_aws_auto_config.py
+++ b/kfai_sql_chemistry/test/test_aws_auto_config.py
@@ -10,20 +10,16 @@ from kfai_sql_chemistry.aws.aws_db_config import AwsDbConfig
 from kfai_sql_chemistry.db.database_config import DatabaseConfig
 
 
-def setUpModule():
-    os.environ['ENV'] = 'AWS-TEST'
-
-
-def tearDownModule():
-    os.environ['ENV'] = ''
-
-
 class AWSAutoConfigTest(unittest.TestCase):
 
     def setUp(self):
+        os.environ['ENV'] = 'AWS-TEST'
         e = Environment('./kfai_sql_chemistry/test/env')
         e.register_environment("AWS-TEST")
         e.load_env()
+
+    def tearDown(self):
+        os.environ['ENV'] = ''
 
     @mock_secretsmanager
     def test_autodetect(self):
@@ -47,3 +43,29 @@ class AWSAutoConfigTest(unittest.TestCase):
         }
 
         assert database_map['main'] == cfg
+
+    @mock_secretsmanager
+    def test_autodetect_callable_with_session_callable(self):
+        cfg = DatabaseConfig(
+            username='postgres',
+            password='password',
+            engine='postgresql',
+            host='localhost',
+            port=9000,
+            db_name='postgres',
+            dbname=''
+        )
+        conn = boto3.client("secretsmanager")
+        conn.create_secret(
+            Name="SOMEFAKESECRETID", SecretString=cfg.to_json()
+        )
+        print(conn.get_secret_value(SecretId='SOMEFAKESECRETID'))
+
+        database_map: Dict[str, DatabaseConfig] = {
+            "main": AwsDbConfig(
+                boto3_secrets_client=lambda: boto3.client("secretsmanager")
+            ).detect_db_config('main')
+        }
+
+        assert database_map['main'] == cfg
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+
+[tool.taskipy.tasks]
+"test"                = "python -m pytest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ boto3==1.17.44
 kungfuai-env==0.2.1
 moto==2.0.4
 pytest==6.2.2
+taskipy
+poetry


### PR DESCRIPTION
In our CU project, we had an issue were we wanted to be able to construct the session when we know its time to connect, and not before that.

That way, people who do not have secrets access locally can still test and develop with no issues.